### PR TITLE
Add fork acknowledgment to README and make MIT copyright notice compliant

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Rust-iendo Barcelona
+Copyright for portions of yarte are held by Dirkjan Ochtman as part of askama. All other portions are Copyright (c) 2019 Rust-iendo Barcelona
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ We are not looking for anything other than render HTML5 and text as fast as poss
 You can open a pull request in another case.
 
 ## Acknowledgment
-Yarte is based on all previous templates engines, syntax as well as its documentation 
+Yarte is based on a fork of the [Askama](https://github.com/djc/askama) templating framework for Rust. It aspires to learn from all previous templates engines: syntax as well as its documentation 
 is highly influenced by [Handlebars][handlebars]. Implemented mainly with `nom`, 
 `memchr` and `syn`, among others crates . As many ideas as possible used in 
 Yarte are from other repositories. Comments in the code clarify which ideas are used, 


### PR DESCRIPTION
This PR updates the README's "Acknowledgement" section to credit the base project for `yarte`, [`askama`](https://github.com/djc/askama), and amends the copyright notice in LICENSE-MIT to comply with the license terms of the base project, following the advice of [this answer on Stack Exchange](https://softwareengineering.stackexchange.com/a/277699/145081).