### PR TITLE
yarte_format

### DIFF
--- a/yarte_codegen/src/fn_fmt.rs
+++ b/yarte_codegen/src/fn_fmt.rs
@@ -30,7 +30,7 @@ impl<T: CodeGen> CodeGen for FnFmtCodeGen<T> {
             {
                 use std::fmt::Write;
                 let mut buf = String::with_capacity(#size_hint);
-                let _ = write!(buf, "{}", yarte_write::DisplayFn::new(|_fmt| {
+                let _ = write!(buf, "{}", yarte_format::DisplayFn::new(|_fmt| {
                     #body
                     Ok(())
                 }));

--- a/yarte_codegen/src/html.rs
+++ b/yarte_codegen/src/html.rs
@@ -1,44 +1,47 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 
 use yarte_dom::DOMFmt;
 
 use super::{CodeGen, EachCodeGen, IfElseCodeGen, HIR};
 
-pub struct HTMLCodeGen;
+pub struct HTMLCodeGen(pub &'static str);
 
 impl EachCodeGen for HTMLCodeGen {}
 
 impl IfElseCodeGen for HTMLCodeGen {}
 impl CodeGen for HTMLCodeGen {
     fn gen(&mut self, v: Vec<HIR>) -> TokenStream {
-        gen(self, v)
+        let parent = self.0;
+        gen(self, v, parent)
     }
 }
 
-pub struct HTMLMinCodeGen;
+pub struct HTMLMinCodeGen(pub &'static str);
 impl EachCodeGen for HTMLMinCodeGen {}
 impl IfElseCodeGen for HTMLMinCodeGen {}
 
 impl CodeGen for HTMLMinCodeGen {
     fn gen(&mut self, v: Vec<HIR>) -> TokenStream {
+        let parent = self.0;
         let dom: DOMFmt = v.into();
-        gen(self, dom.0)
+        gen(self, dom.0, parent)
     }
 }
 
-fn gen<C>(codegen: &mut C, v: Vec<HIR>) -> TokenStream
+fn gen<C>(codegen: &mut C, v: Vec<HIR>, parent: &str) -> TokenStream
 where
     C: CodeGen + EachCodeGen + IfElseCodeGen,
 {
     let mut tokens = TokenStream::new();
+    let parent = format_ident!("{}", parent);
     for i in v {
         use HIR::*;
         tokens.extend(match i {
             Local(a) => quote!(#a),
             Lit(a) => quote!(_fmt.write_str(#a)?;),
-            Safe(a) => quote!(::std::fmt::Display::fmt(&(#a), _fmt)?;),
-            Expr(a) => quote!(::yarte::Render::render(&(#a), _fmt)?;),
+            Safe(a) => quote!(std::fmt::Display::fmt(&(#a), _fmt)?;),
+            Expr(a) => quote!(#parent::Render::render(&(#a), _fmt)?;),
             Each(a) => codegen.gen_each(*a),
             IfElse(a) => codegen.gen_if_else(*a),
         })

--- a/yarte_format/Cargo.toml
+++ b/yarte_format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarte_format"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
 edition = "2018"
 description = "Proc-macro, compiled Handlebars"

--- a/yarte_format/src/lib.rs
+++ b/yarte_format/src/lib.rs
@@ -1,16 +1,18 @@
-#![cfg(feature = "nightly")]
+#![cfg(nightly)]
 #![feature(proc_macro_hygiene)]
 
-/// Adapted from [`fomat`](https://github.com/krdln/fomat-macros)
+/// Adapted and improve from [`fomat`](https://github.com/krdln/fomat-macros)
 use std::{
     cell::Cell,
     fmt::{self, Display, Formatter},
 };
 
-pub use yarte_derive::yformat;
+pub use yarte_derive::{yformat, yformat_html};
 pub use yarte_helpers::{helpers::Render, recompile, Error, Result};
 
-#[doc(hidden)]
+/// Closure wrapper
+///
+/// Wrap closure in mutable reference for dispatch it
 pub struct DisplayFn<F: FnOnce(&mut Formatter) -> fmt::Result>(std::cell::Cell<Option<F>>);
 
 impl<F: FnOnce(&mut Formatter) -> fmt::Result> DisplayFn<F> {
@@ -19,6 +21,7 @@ impl<F: FnOnce(&mut Formatter) -> fmt::Result> DisplayFn<F> {
     }
 }
 
+// Remove double replace in favor of single by cell::Cell::take
 impl<F: FnOnce(&mut Formatter) -> fmt::Result> Display for DisplayFn<F> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         self.0.take().ok_or(fmt::Error).and_then(|cl| cl(f))

--- a/yarte_format/tests/lib.rs
+++ b/yarte_format/tests/lib.rs
@@ -1,12 +1,90 @@
-#![cfg(feature = "nightly")]
+#![cfg(nightly)]
 #![feature(proc_macro_hygiene)]
 
-use yarte_write::yformat;
+use yarte_format::{yformat, yformat_html};
 
 #[test]
 fn test() {
     let world = "World";
     let res = yformat!("Hello {{ world }}!");
 
+    eprintln!("{}", res);
     assert_eq!(res, "Hello World!")
+}
+
+#[test]
+fn test_hello() {
+    let name = "World";
+    let res = yformat!("{{> hello }}");
+
+    assert_eq!(res, "Hello, World!")
+}
+
+#[test]
+fn test_brackets() {
+    assert_eq!("{{}", yformat!("{{}"));
+}
+
+#[test]
+fn test_brackets2() {
+    assert_eq!("{{{}", yformat!("{{{}"));
+}
+
+#[test]
+fn test_variables() {
+    let strvar = "foo";
+    let num = 42;
+    let i18n = "Iñtërnâtiônàlizætiøn";
+    assert_eq!(
+        "hello world, foo\nwith number: 42\nIñtërnâtiônàlizætiøn is important\nin vars too: \
+         Iñtërnâtiônàlizætiøn",
+        yformat!("{{> simple }}")
+    );
+}
+
+#[test]
+fn test_escape() {
+    let name = "<>&\"'/";
+
+    assert_eq!(
+        "Hello, &lt;&gt;&amp;&quot;&#x27;&#x2f;!",
+        yformat_html!("{{> hello }}")
+    );
+}
+
+#[test]
+fn test_if() {
+    let cond = true;
+    assert_eq!("true", yformat!("{{> if }}"));
+}
+
+#[test]
+fn test_else_false() {
+    let cond = false;
+    assert_eq!("     \n    false\n", yformat!("{{> else }}"));
+}
+
+#[test]
+fn test_else_true() {
+    let cond = true;
+    assert_eq!("     \n true", yformat!("{{> else }}"));
+}
+
+#[test]
+fn test_else_if() {
+    let cond = false;
+    let check = true;
+    assert_eq!(" checked ", yformat!("{{> else-if }}"));
+}
+
+#[test]
+fn test_comment() {
+    assert_eq!("", yformat!("{{> comment }}"));
+}
+
+#[test]
+fn test_noescape() {
+    let a = "&";
+
+    assert_eq!("&", yformat!("{{ a }}"));
 }

--- a/yarte_format/yarte.toml
+++ b/yarte_format/yarte.toml
@@ -1,0 +1,2 @@
+[main]
+dir = "../yarte/templates"


### PR DESCRIPTION
It uses much of the coverage of yarte, it has the minimum to see that the front end extension is correct.

I want to use it with `web_sys::Node::set_text_content`. 
It will be used in conjunction with the intermediate representation serializer to the shared front end.

It can be used anywhere, although of course it is slower than if the types are marked, not much more.

#37 