### PR TITLE
Auto deref and auto copy for render fixed traits

### DIFF
--- a/yarte/src/lib.rs
+++ b/yarte/src/lib.rs
@@ -60,11 +60,20 @@ pub trait TemplateFixedTrait {
     /// # const N: usize = 1;
     /// let buf = TemplateFixedTrait::call(&mut [MaybeUninit::uninit(); N]).expect("buffer overflow");
     /// ```
-    // TODO: consume function `ccall` for elide reference small types
     unsafe fn call<'call>(
         &self,
         buf: &'call mut [std::mem::MaybeUninit<u8>],
     ) -> Option<&'call [u8]>;
+
+    /// Writes to buffer and drop
+    ///
+    /// # Safety
+    /// Not respect the lifetime bounds it's possible borrow mut when it's borrow
+    /// ```rust,ignore
+    /// # const N: usize = 1;
+    /// let buf = TemplateFixedTrait::ccall(&mut [MaybeUninit::uninit(); N]).expect("buffer overflow");
+    /// ```
+    unsafe fn ccall(self, buf: &mut [std::mem::MaybeUninit<u8>]) -> Option<&[u8]>;
 }
 
 #[cfg(feature = "fixed")]
@@ -85,8 +94,9 @@ pub use TemplateFixedTrait as TemplateFixedMin;
 /// Template trait
 pub trait TemplateBytesTrait {
     /// Writes to buffer and return it freeze
-    // TODO: consume function `ccall` for elide reference small types
     fn call(&self, capacity: usize) -> Option<bytes::Bytes>;
+    /// Writes to buffer and return it freeze and drop
+    fn ccall(self, capacity: usize) -> Option<bytes::Bytes>;
 }
 
 #[cfg(all(feature = "bytes_buff", feature = "html-min"))]

--- a/yarte/src/lib.rs
+++ b/yarte/src/lib.rs
@@ -60,6 +60,7 @@ pub trait TemplateFixedTrait {
     /// # const N: usize = 1;
     /// let buf = TemplateFixedTrait::call(&mut [MaybeUninit::uninit(); N]).expect("buffer overflow");
     /// ```
+    // TODO: consume function `ccall` for elide reference small types
     unsafe fn call<'call>(
         &self,
         buf: &'call mut [std::mem::MaybeUninit<u8>],
@@ -84,6 +85,7 @@ pub use TemplateFixedTrait as TemplateFixedMin;
 /// Template trait
 pub trait TemplateBytesTrait {
     /// Writes to buffer and return it freeze
+    // TODO: consume function `ccall` for elide reference small types
     fn call(&self, capacity: usize) -> Option<bytes::Bytes>;
 }
 

--- a/yarte/tests/fixed.rs
+++ b/yarte/tests/fixed.rs
@@ -26,6 +26,31 @@ fn test_variables() {
          Iñtërnâtiônàlizætiøn"
             .as_bytes()
     );
+    assert_eq!(
+        unsafe { s.ccall(&mut [MaybeUninit::uninit(); 128]) }.unwrap(),
+        "hello world, foo\nwith number: 42\nIñtërnâtiônàlizætiøn is important\nin vars too: \
+         Iñtërnâtiônàlizætiøn"
+            .as_bytes()
+    );
+}
+
+#[derive(TemplateFixed)]
+#[template(src = "{{ (&&&&&&&&&n) }}{{ n }}{{ n }}")]
+struct AutoCopy {
+    n: usize,
+}
+
+#[test]
+fn test_auto_copy() {
+    let s = AutoCopy { n: 0 };
+    assert_eq!(
+        unsafe { s.call(&mut [MaybeUninit::uninit(); 128]) }.unwrap(),
+        b"000"
+    );
+    assert_eq!(
+        unsafe { s.ccall(&mut [MaybeUninit::uninit(); 128]) }.unwrap(),
+        b"000"
+    );
 }
 
 #[derive(TemplateFixed)]

--- a/yarte_helpers/src/at_helpers.rs
+++ b/yarte_helpers/src/at_helpers.rs
@@ -7,6 +7,7 @@ pub mod json {
 
     use crate::helpers::io_fmt::IoFmt;
 
+    #[derive(Clone, Copy)]
     pub struct Json<'a, T: Serialize>(pub &'a T);
 
     pub trait AsJson {
@@ -24,6 +25,7 @@ pub mod json {
         }
     }
 
+    #[derive(Clone, Copy)]
     pub struct JsonPretty<'a, T: Serialize>(pub &'a T);
 
     pub trait AsJsonPretty {

--- a/yarte_helpers/src/helpers/integers.rs
+++ b/yarte_helpers/src/helpers/integers.rs
@@ -256,7 +256,7 @@ mod tests {
 
         let mut state = 88172645463325252u64;
 
-        for _ in 0..100 {
+        for _ in 0..1_000_000 {
             // xorshift
             state ^= state << 13;
             state ^= state >> 7;


### PR DESCRIPTION
Add new methods `ccall` for render and consume template
Closes #139 