### PR TITLE
Check remove example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,6 @@ script:
     cd yarte && cargo test -- --nocapture \
     && cargo test --features bytes-buf    \
     && cargo test --features fixed        \
+    && cd ../example                      \
+    && cargo run --release                \
     && cd ..

--- a/example/yarte.toml
+++ b/example/yarte.toml
@@ -1,7 +1,6 @@
 # root dir of templates
 [main]
 dir = "templates"
-debug = "code"
 
 # Alias for partials. In call, change the start of partial path with one of this, if exist.
 [partials]

--- a/yarte/templates/deep/more/card/form.hbs
+++ b/yarte/templates/deep/more/card/form.hbs
@@ -1,0 +1,16 @@
+{{!
+    Form: What is your name?
+!}}
+{{> ../deep/welcome id = "welcome", tag = "h1", tail = '!' ~}}
+<div>
+    <h3>What is your name?</h3>
+    <form>
+        {{! Input name !}}
+        Name: <input type="text" name="name" /><br/>
+        {{! Input last name !}}
+        Last name: <input type="text" name="lastname"/><br/>
+        <p>
+            <input type="submit">
+        </p>
+    </form>
+</div>

--- a/yarte/templates/deep/more/card/hi.hbs
+++ b/yarte/templates/deep/more/card/hi.hbs
@@ -1,0 +1,8 @@
+{{!
+    Hi message:
+    args:
+        - lastname
+        - name
+!}}
+<h1>Hi, {{ name }} {{ lastname }}!</h1>
+{{~> alias/welcome id = "hi", tag = 'p', tail = "" }}

--- a/yarte/templates/deep/more/deep/welcome.hbs
+++ b/yarte/templates/deep/more/deep/welcome.hbs
@@ -1,0 +1,11 @@
+{{!
+    Welcome card:
+    args:
+        - tag
+        - id
+        - tail
+!}}
+{{#unless tag.is_match(r"^p|(h[1-6])$") && !id.is_empty() }}
+   {{$ "Need static args: tag: str /^h[1-6]$/, id: str" }}
+{{/unless }}
+<{{ tag }} id="{{ id }}" class="welcome">Welcome{{ tail }}</{{ tag }}>

--- a/yarte/templates/deep/more/doc/head.hbs
+++ b/yarte/templates/deep/more/doc/head.hbs
@@ -1,0 +1,7 @@
+{{# unless title.is_str() && !title.is_empty() }}
+    {{$ "Need static args: title: str" }}
+{{/unless}}
+<head>
+    <meta charset="utf-8"/>
+    <title>{{ title }}</title>
+</head>

--- a/yarte/templates/deep/more/doc/t.hbs
+++ b/yarte/templates/deep/more/doc/t.hbs
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/yarte/templates/example/base.hbs
+++ b/yarte/templates/example/base.hbs
@@ -1,0 +1,8 @@
+{{! Simple example !}}
+{{> doc/t }}
+<html>
+{{> doc/head }}
+<body>
+{{> @partial-block }}
+</body>
+</html>

--- a/yarte/templates/example/deep/more/card/form.hbs
+++ b/yarte/templates/example/deep/more/card/form.hbs
@@ -1,0 +1,16 @@
+{{!
+    Form: What is your name?
+!}}
+{{> ../deep/welcome id = "welcome", tag = "h1", tail = '!' ~}}
+<div>
+    <h3>What is your name?</h3>
+    <form>
+        {{! Input name !}}
+        Name: <input type="text" name="name" /><br/>
+        {{! Input last name !}}
+        Last name: <input type="text" name="lastname"/><br/>
+        <p>
+            <input type="submit">
+        </p>
+    </form>
+</div>

--- a/yarte/templates/example/deep/more/card/hi.hbs
+++ b/yarte/templates/example/deep/more/card/hi.hbs
@@ -1,0 +1,8 @@
+{{!
+    Hi message:
+    args:
+        - lastname
+        - name
+!}}
+<h1>Hi, {{ name }} {{ lastname }}!</h1>
+{{~> alias/welcome id = "hi", tag = 'p', tail = "" }}

--- a/yarte/templates/example/deep/more/deep/welcome.hbs
+++ b/yarte/templates/example/deep/more/deep/welcome.hbs
@@ -1,0 +1,11 @@
+{{!
+    Welcome card:
+    args:
+        - tag
+        - id
+        - tail
+!}}
+{{#unless tag.is_match(r"^p|(h[1-6])$") && !id.is_empty() }}
+   {{$ "Need static args: tag: str /^h[1-6]$/, id: str" }}
+{{/unless }}
+<{{ tag }} id="{{ id }}" class="welcome">Welcome{{ tail }}</{{ tag }}>

--- a/yarte/templates/example/deep/more/doc/head.hbs
+++ b/yarte/templates/example/deep/more/doc/head.hbs
@@ -1,0 +1,7 @@
+{{# unless title.is_str() && !title.is_empty() }}
+    {{$ "Need static args: title: str" }}
+{{/unless}}
+<head>
+    <meta charset="utf-8"/>
+    <title>{{ title }}</title>
+</head>

--- a/yarte/templates/example/deep/more/doc/t.hbs
+++ b/yarte/templates/example/deep/more/doc/t.hbs
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/yarte/templates/example/index.hbs
+++ b/yarte/templates/example/index.hbs
@@ -1,0 +1,8 @@
+{{#> base title = "Actix web" }}
+    {{~#if let Some(name) = query.get("name") }}
+        {{ let lastname = query.get("lastname").ok_or(yarte::Error)? }}
+        {{> card/hi ~}}
+    {{ else ~}}
+        {{> card/form ~}}
+    {{/if ~}}
+{{/base }}

--- a/yarte/templates/example/index_bytes.hbs
+++ b/yarte/templates/example/index_bytes.hbs
@@ -1,0 +1,7 @@
+{{#> base title = "Actix web" }}
+    {{~#if let Some((name, lastname)) = query }}
+        {{> card/hi ~}}
+    {{ else ~}}
+        {{> card/form ~}}
+    {{/if ~}}
+{{/base }}

--- a/yarte/templates/example/index_fixed.hbs
+++ b/yarte/templates/example/index_fixed.hbs
@@ -1,0 +1,8 @@
+{{#> base title = "Actix web" }}
+    {{~#if let Some(name) = query.get("name") }}
+        {{ let lastname = query.get("lastname")? }}
+        {{> card/hi ~}}
+    {{ else ~}}
+        {{> card/form ~}}
+    {{/if ~}}
+{{/base }}

--- a/yarte/tests/example.rs
+++ b/yarte/tests/example.rs
@@ -1,0 +1,61 @@
+#![allow(clippy::uninit_assumed_init)]
+#![cfg(all(feature = "fixed", feature = "bytes-buf", feature = "html-min"))]
+
+use std::collections::HashMap;
+use std::mem::MaybeUninit;
+
+use bytes::Bytes;
+
+use yarte::{TemplateBytesMin, TemplateFixedMin, TemplateMin};
+
+#[derive(TemplateMin)]
+#[template(path = "example/index")]
+struct IndexTemplateMin<'a> {
+    query: &'a HashMap<&'static str, &'static str>,
+}
+
+#[derive(TemplateFixedMin)]
+#[template(path = "example/index_fixed")]
+struct IndexTemplateF<'a> {
+    query: &'a HashMap<&'static str, &'static str>,
+}
+
+#[derive(TemplateBytesMin)]
+#[template(path = "example/index_bytes")]
+struct IndexTemplateB<'a> {
+    query: Option<(&'a str, &'a str)>,
+}
+
+#[test]
+fn main() {
+    let expected =
+        "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>Actix web</title></head><body><h1>Hi, new user!</h1><p id=\"hi\" class=\"welcome\">Welcome</p></body></html>";
+    let mut query = HashMap::new();
+    query.insert("name", "new");
+    query.insert("lastname", "user");
+
+    assert_eq!(IndexTemplateMin { query: &query }.to_string(), expected);
+
+    assert_eq!(
+        unsafe {
+            TemplateFixedMin::call(
+                &IndexTemplateF { query: &query },
+                &mut [MaybeUninit::uninit(); 2048],
+            )
+        }
+        .unwrap(),
+        expected.as_bytes()
+    );
+
+    assert_eq!(
+        TemplateBytesMin::ccall(
+            IndexTemplateB {
+                query: query
+                    .get("name")
+                    .and_then(|name| query.get("lastname").map(|lastname| (*name, *lastname))),
+            },
+            2048,
+        ),
+        Bytes::from(expected)
+    )
+}

--- a/yarte/yarte.toml
+++ b/yarte/yarte.toml
@@ -1,0 +1,9 @@
+# root dir of templates
+[main]
+dir = "templates"
+
+# Alias for partials. In call, change the start of partial path with one of this, if exist.
+[partials]
+alias = "example/deep/more/deep"
+doc = "example/deep/more/doc"
+card = "example/deep/more/card"


### PR DESCRIPTION
When compile example with returns can't alloc because it's too big, compile well in nightly. Compile logic doesn't change in a large time without any error. #147 