### PR TITLE
Remove `bytes::BytesMut` in favor of `buf-min::Buffer` trait

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -10,7 +10,7 @@ members = ["."]
 [dependencies]
 yarte = { path = "../yarte", version = "*", features = ["fixed", "bytes-buf"] }
 itoa = "0.4"
-v_htmlescape = "0.9"
+v_htmlescape = "0.10"
 
 [build-dependencies]
 yarte = { path = "../yarte", version = "*" }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,6 +11,7 @@ members = ["."]
 yarte = { path = "../yarte", version = "*", features = ["fixed", "bytes-buf"] }
 itoa = "0.4"
 v_htmlescape = "0.10"
+bytes = "0.5"
 
 [build-dependencies]
 yarte = { path = "../yarte", version = "*" }

--- a/benches/src/all.rs
+++ b/benches/src/all.rs
@@ -4,6 +4,7 @@ use std::{io, slice};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
+use bytes::BytesMut;
 use itoa;
 use v_htmlescape::f_escape;
 use yarte::{
@@ -181,7 +182,7 @@ fn bytes_teams(b: &mut criterion::Bencher) {
         year: 2015,
         teams: build_teams(),
     };
-    b.iter(|| teams.call(2048));
+    b.iter(|| teams.call::<BytesMut>(2048));
 }
 
 #[derive(TemplateBytesText)]
@@ -196,7 +197,7 @@ fn bytes_text_teams(b: &mut criterion::Bencher) {
         year: 2015,
         teams: build_teams(),
     };
-    b.iter(|| teams.call(2048));
+    b.iter(|| teams.call::<BytesMut>(2048));
 }
 
 #[derive(TemplateBytes)]
@@ -209,7 +210,7 @@ fn bytes_big_table(b: &mut criterion::Bencher, size: usize) {
     let t = BigTableB {
         table: build_big_table(size),
     };
-    b.iter(|| t.call(109915));
+    b.iter(|| t.call::<BytesMut>(109915));
 }
 
 #[derive(TemplateBytesText)]
@@ -222,7 +223,7 @@ fn bytes_text_big_table(b: &mut criterion::Bencher, size: usize) {
     let t = BigTableBT {
         table: build_big_table(size),
     };
-    b.iter(|| t.call(109915));
+    b.iter(|| t.call::<BytesMut>(109915));
 }
 
 // Fixed

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::io::{stdout, Write};
 use std::thread;
 
+use bytes::BytesMut;
 use std::mem::MaybeUninit;
 use yarte::{Template, TemplateBytesMin, TemplateFixedMin, TemplateMin};
 
@@ -52,7 +53,7 @@ fn main() {
     })
     .unwrap();
 
-    let buf = TemplateBytesMin::ccall(
+    let buf = TemplateBytesMin::ccall::<BytesMut>(
         IndexTemplateB {
             query: query
                 .get("name")

--- a/yarte/Cargo.toml
+++ b/yarte/Cargo.toml
@@ -23,14 +23,15 @@ wasm = ["yarte_derive/wasm-server", "json", "bytes-buf"]
 json = ["yarte_helpers/json", "yarte_derive/json", "bytes-buf"]
 html-min = ["yarte_derive/html-min"]
 fixed = ["yarte_helpers/fixed", "yarte_derive/fixed"]
-bytes-buf = ["yarte_helpers/bytes-buf", "yarte_derive/bytes-buf", "bytes"]
+bytes-buf = ["buf-min", "yarte_helpers/bytes-buf", "yarte_derive/bytes-buf"]
 
 [dependencies]
 yarte_derive = { version = "0.11.3", path = "../yarte_derive" }
 yarte_helpers = { version = "0.11.3", path = "../yarte_helpers" }
-bytes = { version = "0.5", optional = true }
+buf-min = { version = "0.1", features = ["bytes-buf"], optional = true }
 
 [dev-dependencies]
+bytes = "0.5"
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/yarte/src/lib.rs
+++ b/yarte/src/lib.rs
@@ -89,12 +89,12 @@ pub trait TemplateBytesTrait {
     ///
     /// # Panics
     /// Render length overflows usize
-    fn call(&self, capacity: usize) -> bytes::Bytes;
+    fn call<B: Buffer>(&self, capacity: usize) -> B::Freeze;
     /// Writes to buffer and return it freeze and drop
     ///
     /// # Panics
     /// Render length overflows usize
-    fn ccall(self, capacity: usize) -> bytes::Bytes;
+    fn ccall<B: Buffer>(self, capacity: usize) -> B::Freeze;
 }
 
 #[cfg(all(feature = "bytes-buf", feature = "html-min"))]
@@ -112,7 +112,7 @@ pub use TemplateBytesTrait as TemplateBytesMin;
 pub use yarte_helpers::helpers::{RenderBytes, RenderBytesA, RenderBytesSafe, RenderBytesSafeA};
 
 #[cfg(any(feature = "bytes-buf", feature = "json"))]
-pub use bytes::{BufMut, Bytes, BytesMut};
+pub use buf_min::Buffer;
 
 #[cfg(feature = "json")]
 pub use yarte_derive::Serialize;

--- a/yarte/tests/at_helpers.rs
+++ b/yarte/tests/at_helpers.rs
@@ -115,7 +115,7 @@ mod json {
     #[cfg(feature = "bytes-buf")]
     mod bytes_buf {
         use super::*;
-        use bytes::Bytes;
+        use bytes::{Bytes, BytesMut};
         use yarte::{TemplateBytes, TemplateBytesText};
 
         #[derive(TemplateBytes)]
@@ -141,13 +141,22 @@ mod json {
             let f = Json { f: 1 };
             let t = JsonTemplateF { f };
 
-            assert_eq!(Bytes::from(serde_json::to_string(&f).unwrap()), t.ccall(0));
+            assert_eq!(
+                Bytes::from(serde_json::to_string(&f).unwrap()),
+                t.ccall::<BytesMut>(0)
+            );
 
             let t = JsonTemplateFT { f };
-            assert_eq!(Bytes::from(serde_json::to_string(&f).unwrap()), t.ccall(0));
+            assert_eq!(
+                Bytes::from(serde_json::to_string(&f).unwrap()),
+                t.ccall::<BytesMut>(0)
+            );
 
             let t = JsonTemplateN { f: JsonN { f: 1 } };
-            assert_eq!(Bytes::from(serde_json::to_string(&f).unwrap()), t.ccall(0));
+            assert_eq!(
+                Bytes::from(serde_json::to_string(&f).unwrap()),
+                t.ccall::<BytesMut>(0)
+            );
         }
     }
 }

--- a/yarte/tests/benchs.rs
+++ b/yarte/tests/benchs.rs
@@ -4,7 +4,7 @@
 
 use std::mem::MaybeUninit;
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 
 use yarte::{
     TemplateBytesMin as TemplateBytes, TemplateFixedMin as TemplateFixed, TemplateMin as Template,
@@ -31,7 +31,10 @@ fn big_table() {
         unsafe { TemplateFixed::call(&table, &mut [MaybeUninit::uninit(); 256]) }.unwrap(),
         expected.as_bytes()
     );
-    assert_eq!(TemplateBytes::ccall(table, 0), Bytes::from(expected))
+    assert_eq!(
+        TemplateBytes::ccall::<BytesMut>(table, 0),
+        Bytes::from(expected)
+    )
 }
 
 #[derive(Template, TemplateFixed, TemplateBytes)]
@@ -73,7 +76,10 @@ fn teams() {
         unsafe { TemplateFixed::call(&teams, &mut [MaybeUninit::uninit(); 256]) }.unwrap(),
         expected.as_bytes()
     );
-    assert_eq!(TemplateBytes::ccall(teams, 0), Bytes::from(expected))
+    assert_eq!(
+        TemplateBytes::ccall::<BytesMut>(teams, 0),
+        Bytes::from(expected)
+    )
 }
 
 #[derive(Template, TemplateFixed, TemplateBytes)]

--- a/yarte/tests/example.rs
+++ b/yarte/tests/example.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::mem::MaybeUninit;
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 
 use yarte::{TemplateBytesMin, TemplateFixedMin, TemplateMin};
 
@@ -48,7 +48,7 @@ fn main() {
     );
 
     assert_eq!(
-        TemplateBytesMin::ccall(
+        TemplateBytesMin::ccall::<BytesMut>(
             IndexTemplateB {
                 query: query
                     .get("name")

--- a/yarte/tests/json.rs
+++ b/yarte/tests/json.rs
@@ -13,7 +13,7 @@ use std::i64;
 use std::string::ToString;
 use std::u64;
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 
 use yarte::{to_bytes, Serialize};
 
@@ -64,7 +64,7 @@ where
     for &(ref value, out) in errors {
         let out = Bytes::from(out.to_string());
 
-        let s = to_bytes(value, 0);
+        let s = to_bytes::<BytesMut, _>(value, 0);
         assert_eq!(s, out);
     }
 }
@@ -109,16 +109,16 @@ fn test_write_f64() {
 #[test]
 fn test_encode_nonfinite_float_yields_null() {
     let e = Bytes::from("null");
-    let v = to_bytes(&std::f64::NAN, 0);
+    let v = to_bytes::<BytesMut, _>(&std::f64::NAN, 0);
     assert_eq!(v, e);
 
-    let v = to_bytes(&std::f64::INFINITY, 0);
+    let v = to_bytes::<BytesMut, _>(&std::f64::INFINITY, 0);
     assert_eq!(v, e);
 
-    let v = to_bytes(&std::f32::NAN, 0);
+    let v = to_bytes::<BytesMut, _>(&std::f32::NAN, 0);
     assert_eq!(v, e);
 
-    let v = to_bytes(&std::f32::INFINITY, 0);
+    let v = to_bytes::<BytesMut, _>(&std::f32::INFINITY, 0);
     assert_eq!(v, e);
 }
 

--- a/yarte/tests/wasm.rs
+++ b/yarte/tests/wasm.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::into_iter_on_ref)]
 #![cfg(feature = "wasm")]
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use yarte::{Serialize, TemplateWasmServer as Template};
 
 #[derive(Serialize)]
@@ -32,7 +32,7 @@ fn wasm_server() {
     };
 
     assert_eq!(
-        t.call(10240),
+        t.call::<BytesMut>(10240),
         Bytes::from(
         "<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table>\
         <thead><tr><th>id</th><th>message</th></tr></thead>\

--- a/yarte_codegen/src/bytes.rs
+++ b/yarte_codegen/src/bytes.rs
@@ -28,16 +28,16 @@ impl<'a, T: CodeGen> BytesCodeGen<'a, T> {
         tokens.extend(self.s.implement_head(
             quote!(#parent::TemplateBytesTrait),
             &quote!(
-                fn call(&self, capacity: usize) -> #parent::Bytes {
+                fn call<B: #parent::Buffer>(&self, capacity: usize) -> B::Freeze {
                     use #parent::*;
-                    let mut bytes_mut = #parent::BytesMut::with_capacity(capacity);
+                    let mut bytes_mut: B = #parent::Buffer::with_capacity(capacity);
                     #nodes
                     bytes_mut.freeze()
                 }
 
-                fn ccall(self, capacity: usize) -> #parent::Bytes {
+                fn ccall<B: #parent::Buffer>(self, capacity: usize) -> B::Freeze {
                     use #parent::*;
-                    let mut bytes_mut = #parent::BytesMut::with_capacity(capacity);
+                    let mut bytes_mut: B = #parent::Buffer::with_capacity(capacity);
                     #nodes
                     bytes_mut.freeze()
                 }

--- a/yarte_helpers/Cargo.toml
+++ b/yarte_helpers/Cargo.toml
@@ -17,19 +17,19 @@ big-num-32 = []
 config = ["serde", "toml"]
 default = ["markup", "config"]
 display-fn = []
-json = ["bytes", "chrono", "serde", "serde_json", "v_jsonescape", "ryu-ad"]
+json = ["buf-min", "chrono", "serde", "serde_json", "v_jsonescape", "ryu-ad"]
 ryu-ad = ["ryu"]
 fixed = ["v_htmlescape", "itoa", "ryu-ad"]
 markup = ["v_htmlescape", "itoa", "dtoa"]
-bytes-buf = ["bytes", "v_htmlescape", "itoa", "ryu-ad"]
+bytes-buf = ["buf-min", "v_htmlescape", "itoa", "ryu-ad"]
 
 [badges]
 travis-ci = { repository = "botika/yarte", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-v_htmlescape = { version = "0.9", optional = true }
-v_jsonescape = { version = "0.1", optional = true }
+v_htmlescape = { version = "0.10", optional = true }
+v_jsonescape = { version = "0.2", optional = true }
 itoa = { version = "0.4", features = ["i128"], optional = true }
 dtoa = { version = "0.4", optional = true }
 ryu = { version = "1.0", optional = true }
@@ -39,7 +39,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 toml = { version = "0.5", optional = true }
 serde_json = { version = "1.0", optional = true }
 
-bytes = { version = "0.5", optional = true }
+buf-min = { version = "0.1", optional = true}
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/yarte_helpers/src/helpers/bytes.rs
+++ b/yarte_helpers/src/helpers/bytes.rs
@@ -55,7 +55,7 @@ macro_rules! str_display {
             impl RenderBytes for $ty {
                  fn render<B: Buffer>(self, buf: &mut B)  {
                     b_escape(self.as_bytes(), buf)
-                }
+                 }
             }
         )*
     };
@@ -70,7 +70,8 @@ macro_rules! itoa_display {
     ($($ty:ty)*) => {
         $(
             impl RenderBytes for $ty {
-                 fn render<B: Buffer>(self, buf: &mut B)  {
+                #[inline(always)]
+                fn render<B: Buffer>(self, buf: &mut B)  {
                     use super::integers::Integer;
                     buf.reserve(Self::MAX_LEN);
                     // Safety: Previous reserve MAX length
@@ -247,6 +248,7 @@ impl<'a, B: Buffer> Writer<'a, B> {
 }
 
 impl<'a, B: Buffer> io::Write for Writer<'a, B> {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.buf.extend_from_slice(buf);
         Ok(buf.len())

--- a/yarte_helpers/src/helpers/mod.rs
+++ b/yarte_helpers/src/helpers/mod.rs
@@ -33,7 +33,6 @@ pub mod ryu;
 
 #[cfg(feature = "json")]
 pub mod json {
-    pub use super::bytes::buf_ptr;
     pub use super::ser_json::{
         begin_array, end_array, end_array_object, end_object, end_object_object, to_bytes,
         to_bytes_mut, write_comma, Serialize,

--- a/yarte_helpers/src/helpers/ser_json/array.rs
+++ b/yarte_helpers/src/helpers/ser_json/array.rs
@@ -3,7 +3,7 @@ use super::*;
 
 impl<T> Serialize for [T; 0] {
     #[inline]
-    fn to_bytes_mut(&self, buf: &mut BytesMut) {
+    fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
         empty_array(buf)
     }
 }
@@ -16,7 +16,7 @@ macro_rules! array_impls {
                 T: Serialize,
             {
                 #[inline]
-                fn to_bytes_mut(&self, buf: &mut BytesMut) {
+                fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
                     let mut i = self.iter();
                     if let Some(first) = i.next() {
                         begin_array(buf);

--- a/yarte_helpers/src/helpers/ser_json/chrono.rs
+++ b/yarte_helpers/src/helpers/ser_json/chrono.rs
@@ -1,7 +1,7 @@
 // Adapted from [`simd-json-derive`](https://github.com/simd-lite/simd-json-derive)
 use std::fmt;
 
-use bytes::BytesMut;
+use buf_min::Buffer;
 use chrono::{DateTime, TimeZone};
 
 use super::{begin_string, end_string, Serialize};
@@ -11,7 +11,7 @@ impl<Tz: TimeZone> Serialize for DateTime<Tz> {
     ///
     /// See [the `serde` module](./serde/index.html) for alternate
     /// serializations.
-    fn to_bytes_mut(&self, buf: &mut BytesMut) {
+    fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
         struct FormatWrapped<'a, D: 'a> {
             inner: &'a D,
         }

--- a/yarte_helpers/src/helpers/ser_json/collections.rs
+++ b/yarte_helpers/src/helpers/ser_json/collections.rs
@@ -10,7 +10,7 @@ macro_rules! vec_like {
             T: Serialize,
         {
             #[inline]
-            fn to_bytes_mut(&self, buf: &mut BytesMut) {
+            fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
                 let mut i = self.iter();
                 if let Some(first) = i.next() {
                     begin_array(buf);
@@ -40,7 +40,7 @@ where
     H: std::hash::BuildHasher,
 {
     #[inline]
-    fn to_bytes_mut(&self, buf: &mut BytesMut) {
+    fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
         let mut i = self.iter();
         if let Some(first) = i.next() {
             begin_array(buf);
@@ -60,19 +60,19 @@ where
 /// Bounded Object keys types
 #[doc(hidden)]
 pub trait SerObjKey: Serialize {
-    fn ser_obj_key(&self, buf: &mut BytesMut);
+    fn ser_obj_key<B: Buffer>(&self, buf: &mut B);
 }
 
 impl SerObjKey for str {
     #[inline]
-    fn ser_obj_key(&self, buf: &mut BytesMut) {
+    fn ser_obj_key<B: Buffer>(&self, buf: &mut B) {
         serialize_str_short(self, buf);
     }
 }
 
 impl SerObjKey for String {
     #[inline]
-    fn ser_obj_key(&self, buf: &mut BytesMut) {
+    fn ser_obj_key<B: Buffer>(&self, buf: &mut B) {
         serialize_str_short(self, buf);
     }
 }
@@ -86,7 +86,7 @@ macro_rules! deref_impl {
         $(#[doc = $doc])*
         impl <$($desc)+ {
             #[inline]
-            fn ser_obj_key(&self, buf: &mut BytesMut) {
+            fn ser_obj_key<B: Buffer>(&self, buf: &mut B) {
                 (**self).ser_obj_key(buf)
             }
         }
@@ -99,7 +99,7 @@ deref_impl!(<T: ?Sized> SerObjKey for Box<T> where T: SerObjKey);
 deref_impl!(<'a, T: ?Sized> SerObjKey for std::borrow::Cow<'a, T> where T: SerObjKey + ToOwned);
 
 impl SerObjKey for char {
-    fn ser_obj_key(&self, buf: &mut BytesMut) {
+    fn ser_obj_key<B: Buffer>(&self, buf: &mut B) {
         begin_string(buf);
         b_escape_char(*self, buf);
         end_string(buf);
@@ -115,7 +115,7 @@ where
     H: std::hash::BuildHasher,
 {
     #[inline]
-    fn to_bytes_mut(&self, buf: &mut BytesMut) {
+    fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
         let mut i = self.iter();
         if let Some((k, v)) = i.next() {
             begin_object(buf);
@@ -141,7 +141,7 @@ where
     V: Serialize,
 {
     #[inline]
-    fn to_bytes_mut(&self, buf: &mut BytesMut) {
+    fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
         let mut i = self.iter();
         if let Some((k, v)) = i.next() {
             begin_object(buf);

--- a/yarte_helpers/src/helpers/ser_json/deref.rs
+++ b/yarte_helpers/src/helpers/ser_json/deref.rs
@@ -9,7 +9,7 @@ macro_rules! deref_impl {
         $(#[doc = $doc])*
         impl <$($desc)+ {
             #[inline]
-            fn to_bytes_mut(&self, buf: &mut BytesMut) {
+            fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
                 (**self).to_bytes_mut(buf)
             }
         }

--- a/yarte_helpers/src/helpers/ser_json/mod.rs
+++ b/yarte_helpers/src/helpers/ser_json/mod.rs
@@ -69,7 +69,7 @@ itoa_display! {
 }
 
 impl Serialize for char {
-    #[inline(always)]
+    #[inline]
     fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
         begin_string(buf);
         b_escape_char(*self, buf);

--- a/yarte_helpers/src/helpers/ser_json/mod.rs
+++ b/yarte_helpers/src/helpers/ser_json/mod.rs
@@ -2,11 +2,10 @@
 
 //! Serialize a Rust data structure into JSON data.
 
-use bytes::{BufMut, Bytes, BytesMut};
-
+use buf_min::Buffer;
 use v_jsonescape::{b_escape, b_escape_char, fallback};
 
-use crate::helpers::bytes::{buf_ptr, render_bool};
+use crate::helpers::bytes::render_bool;
 use crate::helpers::ryu::{Sealed, MAX_SIZE_FLOAT};
 
 mod array;
@@ -16,12 +15,12 @@ mod deref;
 mod tpl;
 
 pub trait Serialize {
-    fn to_bytes_mut(&self, buf: &mut BytesMut);
+    fn to_bytes_mut<B: Buffer>(&self, buf: &mut B);
 
-    fn to_bytes(&self, capacity: usize) -> Bytes {
-        let mut buf = BytesMut::with_capacity(capacity);
+    fn to_bytes<B: Buffer + Sized>(&self, capacity: usize) -> B::Freeze {
+        let mut buf: B = Buffer::with_capacity(capacity);
         self.to_bytes_mut(&mut buf);
-        buf.freeze()
+        Buffer::freeze(buf)
     }
 }
 
@@ -29,8 +28,8 @@ macro_rules! str_display {
     ($($ty:ty)*) => {
         $(
             impl Serialize for $ty {
-                #[inline(always)]
-                 fn to_bytes_mut(&self, buf: &mut BytesMut)  {
+                #[inline]
+                 fn to_bytes_mut<B: Buffer>(&self, buf: &mut B)  {
                     begin_string(buf);
                     b_escape(self.as_bytes(), buf);
                     end_string(buf);
@@ -50,13 +49,13 @@ macro_rules! itoa_display {
         $(
             impl Serialize for $ty {
                 #[inline(always)]
-                 fn to_bytes_mut(&self, buf: &mut BytesMut)  {
+                 fn to_bytes_mut<B: Buffer>(&self, buf: &mut B)  {
                     use super::integers::Integer;
                     buf.reserve(Self::MAX_LEN);
                     // Safety: Previous reserve MAX length
-                    let b = unsafe { self.write_to(buf_ptr(buf)) };
+                    let b = unsafe { self.write_to(buf.buf_ptr()) };
                     // Safety: Wrote `b` bytes
-                    unsafe { buf.advance_mut(b) };
+                    unsafe { buf.advance(b) };
                 }
             }
         )*
@@ -71,7 +70,7 @@ itoa_display! {
 
 impl Serialize for char {
     #[inline(always)]
-    fn to_bytes_mut(&self, buf: &mut BytesMut) {
+    fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
         begin_string(buf);
         b_escape_char(*self, buf);
         end_string(buf);
@@ -80,7 +79,7 @@ impl Serialize for char {
 
 impl Serialize for bool {
     #[inline(always)]
-    fn to_bytes_mut(&self, buf: &mut BytesMut) {
+    fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
         render_bool(*self, buf)
     }
 }
@@ -90,15 +89,15 @@ macro_rules! ryu_display {
     $(
         impl Serialize for $t {
             #[inline(always)]
-            fn to_bytes_mut(&self, buf: &mut BytesMut)  {
+            fn to_bytes_mut<B: Buffer>(&self, buf: &mut B)  {
                 if self.is_nonfinite() {
                     render_null(buf);
                 } else {
                     buf.reserve(MAX_SIZE_FLOAT);
                     // Safety: Previous reserve MAX length
-                    let b = unsafe { self.write_to_ryu_buffer(buf_ptr(buf)) };
+                    let b = unsafe { self.write_to_ryu_buffer(buf.buf_ptr()) };
                     // Safety: Wrote `b` bytes
-                    unsafe { buf.advance_mut(b) };
+                    unsafe { buf.advance(b) };
                 }
             }
         }
@@ -109,136 +108,138 @@ macro_rules! ryu_display {
 ryu_display!(f32 f64);
 
 #[inline]
-pub fn render_null(buf: &mut bytes::BytesMut) {
+pub fn render_null<B: Buffer>(buf: &mut B) {
     buf.extend_from_slice(b"null");
 }
 
 #[inline]
-pub fn begin_string(buf: &mut BytesMut) {
+pub fn begin_string<B: Buffer>(buf: &mut B) {
     buf.reserve(1);
     // Safety: previous reserve 1 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b'"' };
+    unsafe { *buf.buf_ptr() = b'"' };
     // Safety: previous write 1
-    unsafe { buf.advance_mut(1) };
+    unsafe { buf.advance(1) };
 }
 
-#[inline]
-pub fn end_string(buf: &mut BytesMut) {
+#[inline(always)]
+pub fn end_string<B: Buffer>(buf: &mut B) {
     begin_string(buf);
 }
 
 #[inline]
-pub fn empty_array(buf: &mut BytesMut) {
+pub fn empty_array<B: Buffer>(buf: &mut B) {
     buf.reserve(2);
-    // Safety: previous reserve 2 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b'[' };
-    unsafe { *buf_ptr(buf).add(1) = b']' };
+    // Safety: previous reserve 2
+    unsafe { *buf.buf_ptr() = b'[' };
+    unsafe { *buf.buf_ptr().add(1) = b']' };
     // Safety: previous write 2
-    unsafe { buf.advance_mut(2) };
+    unsafe { buf.advance(2) };
 }
 
 #[inline]
-pub fn begin_array(buf: &mut BytesMut) {
+pub fn begin_array<B: Buffer>(buf: &mut B) {
     buf.reserve(1);
     // Safety: previous reserve 1 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b'[' };
+    unsafe { *buf.buf_ptr() = b'[' };
     // Safety: previous write 1
-    unsafe { buf.advance_mut(1) };
+    unsafe { buf.advance(1) };
 }
 
 #[inline]
-pub fn end_array(buf: &mut BytesMut) {
+pub fn end_array<B: Buffer>(buf: &mut B) {
     buf.reserve(1);
     // Safety: previous reserve 1 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b']' };
+    unsafe { *buf.buf_ptr() = b']' };
     // Safety: previous write 1
-    unsafe { buf.advance_mut(1) };
+    unsafe { buf.advance(1) };
 }
 
 #[inline]
-pub fn write_comma(buf: &mut BytesMut) {
+pub fn write_comma<B: Buffer>(buf: &mut B) {
     buf.reserve(1);
-    // Safety: previous reserve 1 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b',' };
+    // Safety: previous reserve 1
+    unsafe { *buf.buf_ptr() = b',' };
     // Safety: previous write 1
-    unsafe { buf.advance_mut(1) };
+    unsafe { buf.advance(1) };
 }
 
 #[inline]
-pub fn empty_object(buf: &mut BytesMut) {
+pub fn empty_object<B: Buffer>(buf: &mut B) {
     buf.reserve(2);
-    // Safety: previous reserve 2 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b'{' };
-    unsafe { *buf_ptr(buf).add(1) = b'}' };
+    // Safety: previous reserve 2
+    unsafe { *buf.buf_ptr() = b'{' };
+    unsafe { *buf.buf_ptr().add(1) = b'}' };
     // Safety: previous write 2
-    unsafe { buf.advance_mut(2) };
+    unsafe { buf.advance(2) };
 }
 
 #[inline]
-pub fn begin_object(buf: &mut BytesMut) {
+pub fn begin_object<B: Buffer>(buf: &mut B) {
     buf.reserve(1);
-    // Safety: previous reserve 1 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b'{' };
+    // Safety: previous reserve 1
+    unsafe { *buf.buf_ptr() = b'{' };
     // Safety: previous write 1
-    unsafe { buf.advance_mut(1) };
+    unsafe { buf.advance(1) };
 }
 
 #[inline]
-pub fn end_object(buf: &mut BytesMut) {
+pub fn end_object<B: Buffer>(buf: &mut B) {
     buf.reserve(1);
-    // Safety: previous reserve 1 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b'}' };
+    // Safety: previous reserve 1
+    unsafe { *buf.buf_ptr() = b'}' };
     // Safety: previous write 1
-    unsafe { buf.advance_mut(1) };
+    unsafe { buf.advance(1) };
 }
 
 #[inline]
-pub fn write_colon(buf: &mut BytesMut) {
+pub fn write_colon<B: Buffer>(buf: &mut B) {
     buf.reserve(1);
-    // Safety: previous reserve 1 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b':' };
+    // Safety: previous reserve 1
+    unsafe { *buf.buf_ptr() = b':' };
     // Safety: previous write 1
-    unsafe { buf.advance_mut(1) };
+    unsafe { buf.advance(1) };
 }
 
 #[inline]
-pub fn end_array_object(buf: &mut BytesMut) {
+pub fn end_array_object<B: Buffer>(buf: &mut B) {
     buf.reserve(2);
-    // Safety: previous reserve 2 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b']' };
-    unsafe { *buf_ptr(buf).add(1) = b'}' };
+    // Safety: previous reserve 2
+    unsafe { *buf.buf_ptr() = b']' };
+    unsafe { *buf.buf_ptr().add(1) = b'}' };
     // Safety: previous write 2
-    unsafe { buf.advance_mut(2) };
+    unsafe { buf.advance(2) };
 }
 
 #[inline]
-pub fn end_object_object(buf: &mut BytesMut) {
+pub fn end_object_object<B: Buffer>(buf: &mut B) {
     buf.reserve(2);
-    // Safety: previous reserve 2 and size_t of MaybeUninit<u8> it's equal to size_t of u8
-    unsafe { *buf_ptr(buf) = b'}' };
-    unsafe { *buf_ptr(buf).add(1) = b'}' };
+    // Safety: previous reserve 2
+    unsafe { *buf.buf_ptr() = b'}' };
+    unsafe { *buf.buf_ptr().add(1) = b'}' };
     // Safety: previous write 2
-    unsafe { buf.advance_mut(2) };
+    unsafe { buf.advance(2) };
 }
 
 #[inline]
-fn serialize_str_short(value: &str, buf: &mut BytesMut) {
+fn serialize_str_short<B: Buffer>(value: &str, buf: &mut B) {
     begin_string(buf);
     fallback::b_escape(value.as_bytes(), buf);
     end_string(buf);
 }
 
 #[inline]
-pub fn to_bytes_mut<T>(value: &T, buf: &mut BytesMut)
+pub fn to_bytes_mut<B, T>(value: &T, buf: &mut B)
 where
+    B: Buffer,
     T: ?Sized + Serialize,
 {
     value.to_bytes_mut(buf)
 }
 
-pub fn to_bytes<T>(value: &T, capacity: usize) -> Bytes
+pub fn to_bytes<B, T>(value: &T, capacity: usize) -> B::Freeze
 where
+    B: Buffer,
     T: ?Sized + Serialize,
 {
-    value.to_bytes(capacity)
+    Serialize::to_bytes::<B>(value, capacity)
 }

--- a/yarte_helpers/src/helpers/ser_json/tpl.rs
+++ b/yarte_helpers/src/helpers/ser_json/tpl.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl Serialize for () {
     #[inline]
-    fn to_bytes_mut(&self, buf: &mut BytesMut) {
+    fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
         render_null(buf)
     }
 }
@@ -17,7 +17,7 @@ macro_rules! tuple_impls {
                 $($name: Serialize,)+
             {
                 #[inline]
-                fn to_bytes_mut(&self, buf: &mut BytesMut) {
+                fn to_bytes_mut<B: Buffer>(&self, buf: &mut B) {
                     begin_array(buf);
                     $(
                         if $n != 0 {

--- a/yarte_hir/Cargo.toml
+++ b/yarte_hir/Cargo.toml
@@ -24,7 +24,7 @@ yarte_helpers = { version = "0.11.3", path = "../yarte_helpers" }
 yarte_parser = { version = "0.11.3", path = "../yarte_parser" }
 
 v_eval = "0.6"
-v_htmlescape = "0.9"
+v_htmlescape = "0.10"
 
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"


### PR DESCRIPTION
Improve rustc optimizations. 