### PR TITLE
Render UUID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "examples/simple",
+    "examples/extra-renders",
     "yarte",
     "yarte_codegen",
     "yarte_derive",

--- a/examples/extra-renders/Cargo.toml
+++ b/examples/extra-renders/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "extra-renders"
+version = "0.0.1"
+authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
+publish = false
+edition = "2018"
+
+workspace = "../.."
+
+[dependencies]
+yarte = { path = "../../yarte", version = "*", features = ["bytes-buf"]  }
+yarte_helpers = { path = "../../yarte_helpers", version = "^0.15.2", features = ["extra-renders"] }
+uuid = "0.8"
+
+[build-dependencies]
+yarte = { path = "../../yarte", version = "*" }
+yarte_helpers = { path = "../../yarte_helpers", version = "*" }

--- a/examples/extra-renders/build.rs
+++ b/examples/extra-renders/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    yarte::recompile::when_changed();
+    if !yarte_helpers::definitely_not_nightly() {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/examples/extra-renders/src/main.rs
+++ b/examples/extra-renders/src/main.rs
@@ -1,0 +1,29 @@
+#![cfg_attr(nightly, feature(proc_macro_hygiene, stmt_expr_attributes))]
+use std::io::{stdout, Write};
+
+use uuid::Uuid;
+use yarte::*;
+
+/// without comma or error
+/// `message: stable/nightly mismatch`
+fn write_str(buffer: String) {
+    stdout().lock().write_all(buffer.as_bytes()).unwrap();
+}
+
+#[cfg(nightly)]
+fn nightly(uuid: &Uuid) {
+    // without comma or error
+    // `message: stable/nightly mismatch`
+    #[rustfmt::skip]
+    write_str(#[html] "{{> hello }}");
+}
+
+fn main() {
+    let uuid = Uuid::nil();
+
+    #[cfg(not(nightly))]
+    write_str(auto!(ywrite_html!(String, "{{> hello }}")));
+
+    #[cfg(nightly)]
+    nightly(&uuid);
+}

--- a/examples/extra-renders/templates/hello.hbs
+++ b/examples/extra-renders/templates/hello.hbs
@@ -1,0 +1,3 @@
+<div class="entry">
+  <h1>{{uuid}}</h1>
+</div>

--- a/yarte_helpers/Cargo.toml
+++ b/yarte_helpers/Cargo.toml
@@ -23,6 +23,8 @@ fixed = ["v_htmlescape", "itoa", "ryu-ad"]
 markup = ["v_htmlescape", "itoa", "dtoa"]
 bytes-buf = ["buf-min", "v_htmlescape", "itoa", "ryu-ad"]
 logger = ["bat", "tempfile", "toolchain_find"]
+extra-renders = ["render-uuid"]
+render-uuid = ["buf-min", "uuid"]
 
 [badges]
 travis-ci = { repository = "botika/yarte", branch = "master" }
@@ -45,6 +47,8 @@ buf-min = { version = "0.6.0", optional = true}
 bat = { version = "0.18", default-features = false, features = ["regex-fancy", "paging"], optional = true }
 tempfile = { version = "3.0", optional = true }
 toolchain_find = { version = "0.2", optional = true }
+
+uuid = { version = "0.8", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/yarte_helpers/Cargo.toml
+++ b/yarte_helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarte_helpers"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
 description = "Helper collection for yarte"
 categories = ["template-engine", "web-programming", "gui"]

--- a/yarte_helpers/src/helpers/bytes.rs
+++ b/yarte_helpers/src/helpers/bytes.rs
@@ -305,3 +305,46 @@ pub(crate) fn render_bool<B: Buffer>(b: bool, buf: &mut B) {
         buf.extend(F);
     }
 }
+
+#[cfg(feature = "render-uuid")]
+mod render_uuid {
+    use crate::helpers::{RenderBytes, RenderBytesSafe};
+    use buf_min::Buffer;
+    use std::slice::from_raw_parts_mut;
+    use uuid::adapter::Hyphenated;
+    use uuid::Uuid;
+
+    macro_rules! imp {
+        ($($ty:ty)+) => {
+            $(impl $ty for Uuid {
+                fn render<B: Buffer>(self, buf: &mut B) {
+                    let len = Hyphenated::LENGTH;
+                    buf.reserve(len);
+                    // Safety: previous reserve length
+                    self.to_hyphenated().encode_lower(unsafe {
+                        from_raw_parts_mut(buf.buf_ptr(), len)
+                    });
+                    // Safety: previous write length
+                    unsafe { buf.advance(len); }
+                }
+            })+
+        };
+    }
+
+    imp!(RenderBytes RenderBytesSafe);
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn test() {
+            let mut buf = String::new();
+            let u = Uuid::from_u128(0x1a);
+            let res = u.to_string();
+            RenderBytes::render(u, &mut buf);
+
+            assert_eq!(res, buf);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #225 
When use `std::fmt::Display` implementation, use safe expressions:
```handlebars
{{{ uuid }}}
```